### PR TITLE
feat: use lru cache for supplier cache

### DIFF
--- a/scripts/cacheBenchmark.ts
+++ b/scripts/cacheBenchmark.ts
@@ -1,0 +1,33 @@
+import { LRUCache } from 'lru-cache';
+
+const ITERATIONS = 10000;
+
+const cache = new LRUCache<string, number>({
+  max: ITERATIONS,
+  ttl: 1000 * 60,
+});
+
+console.log(`Benchmarking LRUCache with ${ITERATIONS} entries`);
+
+const startMem = process.memoryUsage().heapUsed;
+console.time('populate');
+for (let i = 0; i < ITERATIONS; i++) {
+  cache.set(`key-${i}`, i);
+}
+console.timeEnd('populate');
+const afterPopulateMem = process.memoryUsage().heapUsed;
+
+console.time('lookup');
+for (let i = 0; i < ITERATIONS; i++) {
+  cache.get(`key-${i}`);
+}
+console.timeEnd('lookup');
+const afterLookupMem = process.memoryUsage().heapUsed;
+
+const populateMemMB = (afterPopulateMem - startMem) / 1024 / 1024;
+const totalMemMB = (afterLookupMem - startMem) / 1024 / 1024;
+
+console.log(`Memory used to populate cache: ${populateMemMB.toFixed(2)} MB`);
+console.log(`Total memory used after lookups: ${totalMemMB.toFixed(2)} MB`);
+console.log(`Cache size: ${cache.size}`);
+


### PR DESCRIPTION
## Summary
- replace Map-based supplier cache with LRU cache using size limit and TTL
- remove manual eviction and track hit/miss statistics
- add benchmark script for cache memory usage and lookup time

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS2802: Type 'Map<string, PipelineModule>' can only be iterated...)*
- `npx tsx scripts/cacheBenchmark.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a79007c9c483218512e05880cb6096