### PR TITLE
refactor: use shared accurateMatchingService instance

### DIFF
--- a/server/services/batchEnrichmentMonitor.ts
+++ b/server/services/batchEnrichmentMonitor.ts
@@ -18,7 +18,7 @@ import { addressValidationService } from './addressValidationService';
 import { MastercardApiService } from './mastercardApi';
 import { akkioService } from './akkioService';
 import { supplierCacheService } from './supplierCacheService';
-import { AccurateMatchingService } from './accurateMatchingService';
+import { accurateMatchingService } from './accurateMatchingService';
 
 const MONITOR_INTERVAL = 60000; // Check every 60 seconds (REDUCED from 10s for production)
 const BATCH_TIMEOUT = 30 * 60 * 1000; // 30 minutes timeout for stuck batches
@@ -28,11 +28,8 @@ class BatchEnrichmentMonitor {
   private isRunning = false;
   private monitorInterval: NodeJS.Timeout | null = null;
   private processingBatch = false; // PRODUCTION FIX: Track if processing to prevent overlap
-  private accurateMatchingService: AccurateMatchingService;
 
-  constructor() {
-    this.accurateMatchingService = new AccurateMatchingService();
-  }
+  constructor() {}
 
   /**
    * Start monitoring batches for enrichment
@@ -246,7 +243,7 @@ class BatchEnrichmentMonitor {
             const searchName = classification.originalName || classification.cleanedName;
             
             // Create a promise for the sophisticated fuzzy matching
-            const searchPromise = this.accurateMatchingService.findBestMatch(searchName, 5);
+            const searchPromise = accurateMatchingService.findBestMatch(searchName, 5);
 
             // Create a timeout promise (5 seconds per record)
             const timeoutPromise = new Promise((_, reject) => 

--- a/server/services/payeeMatchingService.ts
+++ b/server/services/payeeMatchingService.ts
@@ -4,7 +4,7 @@ import { storage } from '../storage';
 import type { PayeeClassification } from '@shared/schema';
 import { supplierCacheService } from './supplierCacheService';
 import { memoryOptimizedCache } from './memoryOptimizedSupplierCache';
-import { AccurateMatchingService } from './accurateMatchingService';
+import { accurateMatchingService } from './accurateMatchingService';
 import OpenAI from 'openai';
 
 // Configuration interface for matching options
@@ -19,13 +19,11 @@ export interface MatchingOptions {
 // Service to handle payee matching workflow
 export class PayeeMatchingService {
   private openai: OpenAI | null = null;
-  private accurateMatchingService: AccurateMatchingService;
   
   constructor() {
     if (process.env.OPENAI_API_KEY) {
       this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
     }
-    this.accurateMatchingService = new AccurateMatchingService();
   }
 
   async matchPayeeWithBigQuery(
@@ -62,9 +60,9 @@ export class PayeeMatchingService {
       }
       
       console.log('[PayeeMatching] Starting sophisticated Finexio match for:', classification.cleanedName);
-      
+
       // Use AccurateMatchingService for sophisticated 6-algorithm fuzzy matching
-      const matchResult = await this.accurateMatchingService.findBestMatch(classification.cleanedName);
+      const matchResult = await accurateMatchingService.findBestMatch(classification.cleanedName);
       console.log('[PayeeMatching] Sophisticated match result:', matchResult.bestMatch ? 'FOUND' : 'NO MATCH');
       
       // If no match found with sophisticated matching, return early

--- a/test-direct-fuzzy.ts
+++ b/test-direct-fuzzy.ts
@@ -1,11 +1,9 @@
-import { AccurateMatchingService } from './server/services/accurateMatchingService';
+import { accurateMatchingService } from './server/services/accurateMatchingService';
 import { db } from './server/db';
 import { payeeClassifications } from './shared/schema';
 import { eq } from 'drizzle-orm';
 
 async function testDirectFuzzyMatching() {
-  const service = new AccurateMatchingService();
-  
   console.log('Testing fuzzy matching directly for key records...\n');
   
   // Get specific test records that should fuzzy match
@@ -21,7 +19,7 @@ async function testDirectFuzzyMatching() {
     console.log(`\n=== Testing: "${name}" ===`);
     
     try {
-      const result = await service.findBestMatch(name, 5);
+      const result = await accurateMatchingService.findBestMatch(name, 5);
       
       console.log(`Found ${result.matches.length} matches`);
       console.log(`Best match confidence: ${result.confidence}`);

--- a/test-direct-matching.ts
+++ b/test-direct-matching.ts
@@ -1,8 +1,6 @@
-import { AccurateMatchingService } from './server/services/accurateMatchingService';
+import { accurateMatchingService } from './server/services/accurateMatchingService';
 
 async function testDirectMatching() {
-  const service = new AccurateMatchingService();
-  
   const testNames = [
     'GRAY MEDIA GROUP INC',
     'Gray Media Group Inc.',
@@ -16,7 +14,7 @@ async function testDirectMatching() {
   
   for (const name of testNames) {
     console.log(`Testing: "${name}"`);
-    const result = await service.findBestMatch(name, 5);
+    const result = await accurateMatchingService.findBestMatch(name, 5);
     
     if (result.bestMatch) {
       console.log(`  ✅ Found: "${result.bestMatch.payeeName}" (${Math.round(result.confidence * 100)}%)`);


### PR DESCRIPTION
## Summary
- import the singleton `accurateMatchingService` in payee and batch services
- drop local AccurateMatchingService fields and use the shared instance
- update direct test scripts to reference the shared service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a79004d6208321a35a9d969a5d8abe