### PR TITLE
feat: add debug flag for fuzzy matcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ MASTERCARD_ENVIRONMENT=production
 
 # Database URL (automatically set by Replit)
 # DATABASE_URL=postgresql://...
+
+# Enable verbose debug logging for fuzzy matcher (set to 'true' to enable)
+ENABLE_DEBUG=false

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -54,7 +54,10 @@ NODE_ENV=production
 PORT=3000
 OPENAI_API_KEY=your_key
 DATABASE_URL=your_db_url
+ENABLE_DEBUG=false # set to true to enable fuzzy matcher debug logs
 ```
+
+- `ENABLE_DEBUG`: Enables detailed fuzzy matcher logs. Defaults to `false` in production.
 
 ## Database Setup
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -161,4 +161,7 @@ NODE_ENV=development|production
 OPENAI_API_KEY=your_key
 DATABASE_URL=postgresql://...
 PORT=3000
+ENABLE_DEBUG=false # set to true to enable fuzzy matcher debug logs
 ```
+
+- `ENABLE_DEBUG`: Enables detailed logging in the fuzzy matcher. Defaults to `true` in development and `false` in production.


### PR DESCRIPTION
## Summary
- add `enableDebug` flag to FuzzyMatcher and gate console logs behind it
- document optional `ENABLE_DEBUG` env var in development and deployment guides
- include `ENABLE_DEBUG` in example environment configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a79002e47c83219981144ee6c78484