### PR TITLE
Cascade batch deletion

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -718,14 +718,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         console.error('Error cancelling background processes before deletion:', error);
       }
       
-      // 2. Delete all classifications for this batch
-      await storage.deleteBatchClassifications(batchId);
-      
-      // 3. Delete the batch itself
-      await storage.deleteUploadBatch(batchId);
-      
+      // 2. Delete the batch and cascade classifications
+      const result = await storage.deleteUploadBatch(batchId);
+
       console.log(`Batch ${batchId} successfully deleted with all background processes stopped`);
-      res.json({ success: true });
+      res.json({ success: true, ...result });
     } catch (error) {
       console.error("Error deleting batch:", error);
       res.status(500).json({ error: "Internal server error" });
@@ -739,14 +736,22 @@ export async function registerRoutes(app: Express): Promise<Server> {
       
       // Get all batches for the user
       const batches = await storage.getUserUploadBatches(userId);
-      
-      // Delete classifications and batches for each
-      for (const batch of batches) {
-        await storage.deleteBatchClassifications(batch.id);
-        await storage.deleteUploadBatch(batch.id);
-      }
-      
-      res.json({ success: true, deletedCount: batches.length });
+
+      // Delete batches in parallel with cascading classifications
+      const results = await Promise.all(
+        batches.map((batch) => storage.deleteUploadBatch(batch.id))
+      );
+
+      const summary = {
+        success: true,
+        deletedBatches: results.length,
+        deletedClassifications: results.reduce(
+          (total, r) => total + r.classificationsDeleted,
+          0
+        ),
+      };
+
+      res.json(summary);
     } catch (error) {
       console.error("Error deleting all batches:", error);
       res.status(500).json({ error: "Internal server error" });

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -64,7 +64,7 @@ export const uploadBatches = pgTable("upload_batches", {
 
 export const payeeClassifications = pgTable("payee_classifications", {
   id: serial("id").primaryKey(),
-  batchId: integer("batch_id").notNull(),
+  batchId: integer("batch_id").references(() => uploadBatches.id, { onDelete: "cascade" }).notNull(),
   originalName: text("original_name").notNull(),
   cleanedName: text("cleaned_name").notNull(),
   address: text("address"),

--- a/workers/shared/schema.js
+++ b/workers/shared/schema.js
@@ -35,7 +35,7 @@ exports.uploadBatches = (0, pg_core_1.pgTable)("upload_batches", {
 });
 exports.payeeClassifications = (0, pg_core_1.pgTable)("payee_classifications", {
     id: (0, pg_core_1.serial)("id").primaryKey(),
-    batchId: (0, pg_core_1.integer)("batch_id").notNull(),
+    batchId: (0, pg_core_1.integer)("batch_id").references(() => exports.uploadBatches.id, { onDelete: "cascade" }).notNull(),
     originalName: (0, pg_core_1.text)("original_name").notNull(),
     cleanedName: (0, pg_core_1.text)("cleaned_name").notNull(),
     address: (0, pg_core_1.text)("address"),


### PR DESCRIPTION
## Summary
- remove batch classifications using cascading deletion
- delete multiple upload batches in parallel and return summary
- ensure schema cascades classifications when batches removed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TypeScript compilation errors: server/services/pipelineOrchestrator.ts(252,34), server/storage.ts(189,39), server/storage.ts(202,41), server/storage.ts(203,43), server/storage.ts(674,34), ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a79628aa048321b58f9cf4dbd76eb4