### PR TITLE
feat: add Finexio toggle to matching options

### DIFF
--- a/server/services/payeeMatchingService.ts
+++ b/server/services/payeeMatchingService.ts
@@ -9,7 +9,7 @@ import OpenAI from 'openai';
 
 // Configuration interface for matching options
 export interface MatchingOptions {
-  enableBigQuery?: boolean;
+  enableFinexio?: boolean;
   enableMastercard?: boolean;
   enableAI?: boolean;
   confidenceThreshold?: number;
@@ -53,7 +53,7 @@ export class PayeeMatchingService {
         ...options
       };
 
-      // Skip if Finexio/BigQuery is disabled
+      // Skip if Finexio matching is disabled
       if (opts.enableFinexio === false) {
         console.log('Finexio matching disabled - skipping payee matching');
         return { matched: false };


### PR DESCRIPTION
## Summary
- add `enableFinexio` flag to matching options
- remove leftover BigQuery wording in payee matching service

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68a79de49f148321a60bec8717327e11