### PR TITLE
chore: remove unused unified matcher

### DIFF
--- a/server/services/accurateMatchingService.ts
+++ b/server/services/accurateMatchingService.ts
@@ -2,7 +2,6 @@ import { sql } from 'drizzle-orm';
 import { db } from '../db';
 import type { CachedSupplier } from '@shared/schema';
 import { fuzzyMatcher } from './fuzzyMatcher';
-import { unifiedFuzzyMatcher } from './unifiedFuzzyMatcher';
 
 /**
  * Sophisticated Matching Service using 6-algorithm fuzzy matching


### PR DESCRIPTION
## Summary
- remove leftover `unifiedFuzzyMatcher` import from accurate matching service

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS2322, TS18046, TS2802, TS18046, TS18046, TS7006, TS7006, TS7006, TS7006, TS18046, TS2345, TS2344, TS2344, TS2403, TS2739, TS7053, TS7017, TS7017)*

------
https://chatgpt.com/codex/tasks/task_e_68a79de5fd788321bca740a37565a0ce