### PR TITLE
Centralize environment configuration

### DIFF
--- a/server/apiGateway.ts
+++ b/server/apiGateway.ts
@@ -1,3 +1,4 @@
+import { env } from './config';
 /**
  * API Gateway - Routes requests to microservices via queues
  * This replaces direct service calls with queue-based async processing
@@ -286,7 +287,7 @@ export function queueMiddleware(
  * Feature flag for gradual microservices rollout
  */
 export function useMicroservices(): boolean {
-  return process.env.ENABLE_MICROSERVICES === 'true';
+  return env.ENABLE_MICROSERVICES;
 }
 
 console.log(`🚀 API Gateway initialized (Microservices: ${useMicroservices() ? 'ENABLED' : 'DISABLED'})`);

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,43 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().default(5000),
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+  GOOGLE_MAPS_API_KEY: z.string().optional(),
+  OPENAI_API_KEY: z.string().optional(),
+  MASTERCARD_CONSUMER_KEY: z.string().optional(),
+  MASTERCARD_KEY: z.string().optional(),
+  MASTERCARD_PRIVATE_KEY: z.string().optional(),
+  MASTERCARD_CERT: z.string().optional(),
+  MASTERCARD_KEY_ALIAS: z.string().optional(),
+  MASTERCARD_KEYSTORE_PASSWORD: z.string().optional(),
+  MASTERCARD_KEYSTORE_ALIAS: z.string().optional(),
+  MASTERCARD_CLIENT_ID: z.string().optional(),
+  MASTERCARD_P12_PATH: z.string().optional(),
+  MASTERCARD_ENVIRONMENT: z.enum(['production', 'sandbox']).default('sandbox'),
+  MASTERCARD_WEBHOOK_SECRET: z.string().optional(),
+  ENABLE_MICROSERVICES: z.coerce.boolean().default(false),
+  AKKIO_API_KEY: z.string().optional(),
+  DB_POOL_SIZE: z.coerce.number().default(20),
+  DB_POOL_MIN: z.coerce.number().default(5),
+  REDIS_URL: z.string().optional(),
+  REDIS_HOST: z.string().default('localhost'),
+  REDIS_PORT: z.coerce.number().default(6379),
+  BIGQUERY_PROJECT_ID: z.string().optional(),
+  BIGQUERY_DATASET: z.string().default('SE_Enrichment'),
+  BIGQUERY_TABLE: z.string().default('supplier'),
+  BIGQUERY_MATCH_METRICS_TABLE: z.string().default('fuzzy_match_metrics'),
+  BIGQUERY_CREDENTIALS: z.string().optional(),
+  BIGQUERY_KEY_FILE: z.string().optional(),
+  DISABLE_OPENAI: z.coerce.boolean().default(false),
+});
+
+const _env = envSchema.safeParse(process.env);
+
+if (!_env.success) {
+  console.error('❌ Invalid environment variables:', _env.error.format());
+  throw new Error('Invalid environment variables');
+}
+
+export const env = _env.data;

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,3 +1,4 @@
+import { env } from './config';
 import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
@@ -10,14 +11,14 @@ neonConfig.webSocketConstructor = ws;
 neonConfig.pipelineConnect = false;
 neonConfig.pipelineTLS = false;
 
-if (!process.env.DATABASE_URL) {
+if (!env.DATABASE_URL) {
   throw new Error(
     "DATABASE_URL must be set. Did you forget to provision a database?",
   );
 }
 
 export const pool = new Pool({ 
-  connectionString: process.env.DATABASE_URL,
+  connectionString: env.DATABASE_URL,
   connectionTimeoutMillis: 30000,  // 30 second timeout for high load
   idleTimeoutMillis: 300000,       // 5 minute idle timeout
   max: 20,                         // Reduced for better memory management

--- a/server/db/connectionManager.ts
+++ b/server/db/connectionManager.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
@@ -18,7 +19,7 @@ class DatabaseConnectionManager {
   private reconnectTimer: NodeJS.Timeout | null = null;
   
   constructor() {
-    if (!process.env.DATABASE_URL) {
+    if (!env.DATABASE_URL) {
       throw new Error(
         "DATABASE_URL must be set. Did you forget to provision a database?",
       );
@@ -36,7 +37,7 @@ class DatabaseConnectionManager {
       
       // Create new pool with connection settings
       this.pool = new Pool({ 
-        connectionString: process.env.DATABASE_URL,
+        connectionString: env.DATABASE_URL,
         connectionTimeoutMillis: CONNECTION_TIMEOUT,
         idleTimeoutMillis: 300000, // 5 minutes
         max: 20, // maximum pool size

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import { env } from './config';
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
@@ -88,7 +89,7 @@ app.use((req, res, next) => {
     // ALWAYS serve the app on port 5000
     // this serves both the API and the client.
     // It is the only port that is not firewalled.
-    const port = parseInt(process.env.PORT || '5000');
+    const port = env.PORT;
     server.listen({
       port,
       host: "0.0.0.0",

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
 
@@ -101,7 +102,7 @@ export function errorHandler(
   res.status(statusCode).json({
     error: message,
     ...(details && { details }),
-    ...(process.env.NODE_ENV === 'development' && { stack: err.stack })
+    ...(env.NODE_ENV === 'development' && { stack: err.stack })
   });
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,3 +1,4 @@
+import { env } from './config';
 import type { Express, Request, Response, NextFunction } from "express";
 import { createServer, type Server } from "http";
 import { storage } from "./storage";
@@ -208,7 +209,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.use(compression());
   
   // Request logging
-  if (process.env.NODE_ENV === 'production') {
+  if (env.NODE_ENV === 'production') {
     app.use(morgan('combined'));
   } else {
     app.use(morgan('dev'));
@@ -249,7 +250,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   // API Gateway health check for microservices
   app.get("/api/gateway/health", asyncHandler(async (req, res) => {
-    if (process.env.ENABLE_MICROSERVICES === 'true') {
+    if (env.ENABLE_MICROSERVICES) {
       try {
         const health = await apiGateway.gatewayHealth();
         res.json(health);
@@ -1298,7 +1299,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Import OpenAI for classification
       const openai = await (async () => {
         const OpenAI = (await import('openai')).default;
-        return new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+        return new OpenAI({ apiKey: env.OPENAI_API_KEY });
       })();
       
       // Perform classification using OpenAI
@@ -1406,9 +1407,9 @@ Also provide a SIC code and description if applicable. Respond in JSON format:
   // Mastercard service status
   app.get("/api/mastercard/status", async (req, res) => {
     try {
-      const hasConsumerKey = !!process.env.MASTERCARD_CONSUMER_KEY;
-      const hasKeystorePassword = !!process.env.MASTERCARD_KEYSTORE_PASSWORD;
-      const hasKeystoreAlias = !!process.env.MASTERCARD_KEYSTORE_ALIAS;
+      const hasConsumerKey = !!env.MASTERCARD_CONSUMER_KEY;
+      const hasKeystorePassword = !!env.MASTERCARD_KEYSTORE_PASSWORD;
+      const hasKeystoreAlias = !!env.MASTERCARD_KEYSTORE_ALIAS;
       
       // Check if private key file exists
       const fs = await import('fs');

--- a/server/routes/akkio.ts
+++ b/server/routes/akkio.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Akkio Predictive Analytics API Routes
  * Handles dataset creation, model training, and payment predictions
@@ -47,7 +48,7 @@ router.get('/datasets', async (req, res) => {
 router.get('/models', async (req, res) => {
   try {
     // Check if Akkio is configured
-    if (!process.env.AKKIO_API_KEY) {
+    if (!env.AKKIO_API_KEY) {
       return res.json([]);  // Return empty array when no API key
     }
     

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { Router } from 'express';
 import { db } from '../db';
 import { bigQueryService } from '../services/bigQueryService';
@@ -100,12 +101,12 @@ router.get('/health', async (req, res) => {
     }
 
     // Check Google Maps configuration
-    if (process.env.GOOGLE_MAPS_API_KEY) {
+    if (env.GOOGLE_MAPS_API_KEY) {
       healthCheck.checks.googleMaps = { status: 'ok' };
     }
 
     // Check OpenAI configuration
-    if (process.env.OPENAI_API_KEY) {
+    if (env.OPENAI_API_KEY) {
       healthCheck.checks.openai = { status: 'ok' };
     }
 
@@ -230,10 +231,10 @@ router.get('/health/services', async (req, res) => {
   }
 
   // Check configurations
-  if (process.env.OPENAI_API_KEY) services.openai = 'configured';
-  if (process.env.GOOGLE_MAPS_API_KEY) services.googleMaps = 'configured';
-  if (process.env.MASTERCARD_CONSUMER_KEY) services.mastercard = 'configured';
-  if (process.env.AKKIO_API_KEY) services.akkio = 'configured';
+  if (env.OPENAI_API_KEY) services.openai = 'configured';
+  if (env.GOOGLE_MAPS_API_KEY) services.googleMaps = 'configured';
+  if (env.MASTERCARD_CONSUMER_KEY) services.mastercard = 'configured';
+  if (env.AKKIO_API_KEY) services.akkio = 'configured';
 
   const allHealthy = services.database === 'healthy' && services.bigQuery === 'healthy';
 
@@ -246,30 +247,30 @@ router.get('/health/services', async (req, res) => {
 // Mastercard configuration diagnostic endpoint
 router.get('/health/mastercard', async (req, res) => {
   const diagnostics = {
-    environment: process.env.NODE_ENV,
-    mastercardEnvironment: process.env.NODE_ENV === 'production' ? 'production' : 'sandbox',
-    apiUrl: process.env.NODE_ENV === 'production' 
+    environment: env.NODE_ENV,
+    mastercardEnvironment: env.NODE_ENV === 'production' ? 'production' : 'sandbox',
+    apiUrl: env.NODE_ENV === 'production' 
       ? 'https://api.mastercard.com/track/search' 
       : 'https://sandbox.api.mastercard.com/track/search',
     configuration: {
-      hasConsumerKey: !!process.env.MASTERCARD_CONSUMER_KEY,
-      consumerKeyPreview: process.env.MASTERCARD_CONSUMER_KEY 
-        ? process.env.MASTERCARD_CONSUMER_KEY.substring(0, 10) + '...' 
+      hasConsumerKey: !!env.MASTERCARD_CONSUMER_KEY,
+      consumerKeyPreview: env.MASTERCARD_CONSUMER_KEY 
+        ? env.MASTERCARD_CONSUMER_KEY.substring(0, 10) + '...' 
         : 'NOT SET',
-      hasPrivateKey: !!process.env.MASTERCARD_KEY,
-      hasCertificate: !!process.env.MASTERCARD_CERT,
-      hasKeyAlias: !!process.env.MASTERCARD_KEY_ALIAS,
-      hasKeystorePassword: !!process.env.MASTERCARD_KEYSTORE_PASSWORD,
-      clientId: process.env.MASTERCARD_CONSUMER_KEY?.includes('!') 
-        ? process.env.MASTERCARD_CONSUMER_KEY.split('!')[1]?.substring(0, 10) + '...'
+      hasPrivateKey: !!env.MASTERCARD_KEY,
+      hasCertificate: !!env.MASTERCARD_CERT,
+      hasKeyAlias: !!env.MASTERCARD_KEY_ALIAS,
+      hasKeystorePassword: !!env.MASTERCARD_KEYSTORE_PASSWORD,
+      clientId: env.MASTERCARD_CONSUMER_KEY?.includes('!') 
+        ? env.MASTERCARD_CONSUMER_KEY.split('!')[1]?.substring(0, 10) + '...'
         : 'NOT FOUND IN CONSUMER KEY'
     },
     requiredSecrets: {
-      MASTERCARD_CONSUMER_KEY: !!process.env.MASTERCARD_CONSUMER_KEY ? '✅ SET' : '❌ MISSING',
-      MASTERCARD_KEY: !!process.env.MASTERCARD_KEY ? '✅ SET' : '❌ MISSING', 
-      MASTERCARD_CERT: !!process.env.MASTERCARD_CERT ? '✅ SET (optional)' : '⚠️ NOT SET (optional)',
-      MASTERCARD_KEY_ALIAS: !!process.env.MASTERCARD_KEY_ALIAS ? '✅ SET' : '⚠️ NOT SET',
-      MASTERCARD_KEYSTORE_PASSWORD: !!process.env.MASTERCARD_KEYSTORE_PASSWORD ? '✅ SET' : '⚠️ NOT SET'
+      MASTERCARD_CONSUMER_KEY: !!env.MASTERCARD_CONSUMER_KEY ? '✅ SET' : '❌ MISSING',
+      MASTERCARD_KEY: !!env.MASTERCARD_KEY ? '✅ SET' : '❌ MISSING', 
+      MASTERCARD_CERT: !!env.MASTERCARD_CERT ? '✅ SET (optional)' : '⚠️ NOT SET (optional)',
+      MASTERCARD_KEY_ALIAS: !!env.MASTERCARD_KEY_ALIAS ? '✅ SET' : '⚠️ NOT SET',
+      MASTERCARD_KEYSTORE_PASSWORD: !!env.MASTERCARD_KEYSTORE_PASSWORD ? '✅ SET' : '⚠️ NOT SET'
     },
     status: 'unknown'
   };
@@ -293,7 +294,7 @@ router.get('/mastercard', async (req, res) => {
     const { mastercardApi } = await import('../services/mastercardApi');
 
     const healthStatus = {
-      environment: process.env.NODE_ENV || 'development',
+      environment: env.NODE_ENV,
       mastercardConfigured: mastercardApi.isServiceConfigured(),
       timestamp: new Date().toISOString()
     };

--- a/server/routes/mastercard-webhook.ts
+++ b/server/routes/mastercard-webhook.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { Request, Response, Router } from 'express';
 import crypto from 'crypto';
 import { db } from '../db';
@@ -6,7 +7,7 @@ import { sql } from 'drizzle-orm';
 const router = Router();
 
 // Store webhook secret for signature verification
-const WEBHOOK_SECRET = process.env.MASTERCARD_WEBHOOK_SECRET || '';
+const WEBHOOK_SECRET = env.MASTERCARD_WEBHOOK_SECRET || '';
 
 /**
  * Verify webhook signature from Mastercard

--- a/server/services/addressValidationService.ts
+++ b/server/services/addressValidationService.ts
@@ -1,10 +1,11 @@
+import { env } from '../config';
 import { z } from 'zod';
 import { storage } from '../storage.js';
 import type { PayeeClassification } from '@shared/schema.js';
 import { intelligentAddressService } from './intelligentAddressService.js';
 
 // Configuration
-const GOOGLE_MAPS_API_KEY = process.env.GOOGLE_MAPS_API_KEY;
+const GOOGLE_MAPS_API_KEY = env.GOOGLE_MAPS_API_KEY;
 const GOOGLE_ADDRESS_VALIDATION_API = 'https://addressvalidation.googleapis.com/v1:validateAddress';
 
 // Response types from Google Address Validation API

--- a/server/services/akkioService.ts
+++ b/server/services/akkioService.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Akkio Predictive Analytics Service
  * Handles payment method outcome predictions and data enrichment
@@ -72,13 +73,13 @@ class AkkioService {
   private isInitialized = false;
 
   constructor() {
-    if (!process.env.AKKIO_API_KEY) {
+    if (!env.AKKIO_API_KEY) {
       throw new Error('AKKIO_API_KEY environment variable is required');
     }
     
     // Initialize with REST API approach instead of SDK for now
     this.client = {
-      apiKey: process.env.AKKIO_API_KEY,
+      apiKey: env.AKKIO_API_KEY,
       baseUrl: 'https://api.akkio.com/api/v1' // Correct v2 API base URL
     };
   }

--- a/server/services/batchClassification.ts
+++ b/server/services/batchClassification.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import OpenAI from "openai";
 import type { 
   InsertPayeeClassification 
@@ -5,7 +6,7 @@ import type {
 import { storage } from "../storage";
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY || "",
+  apiKey: env.OPENAI_API_KEY || "",
 });
 
 interface BatchPayee {

--- a/server/services/batchEnrichmentMonitor.ts
+++ b/server/services/batchEnrichmentMonitor.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Batch Enrichment Monitor Service
  * 
@@ -720,7 +721,7 @@ class BatchEnrichmentMonitor {
 export const batchEnrichmentMonitor = new BatchEnrichmentMonitor();
 
 // Auto-start if not in test environment
-if (process.env.NODE_ENV !== 'test') {
+if (env.NODE_ENV !== 'test') {
   setTimeout(() => {
     console.log('Auto-starting batch enrichment monitor...');
     batchEnrichmentMonitor.start();

--- a/server/services/bigQueryService.ts
+++ b/server/services/bigQueryService.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { BigQuery } from '@google-cloud/bigquery';
 import { z } from 'zod';
 
@@ -29,10 +30,10 @@ export class BigQueryService {
   private initialize() {
     try {
       // Check if we have BigQuery credentials
-      if (process.env.BIGQUERY_PROJECT_ID && process.env.BIGQUERY_CREDENTIALS) {
-        const credentials = JSON.parse(process.env.BIGQUERY_CREDENTIALS);
+      if (env.BIGQUERY_PROJECT_ID && env.BIGQUERY_CREDENTIALS) {
+        const credentials = JSON.parse(env.BIGQUERY_CREDENTIALS);
         this.bigquery = new BigQuery({
-          projectId: process.env.BIGQUERY_PROJECT_ID,
+          projectId: env.BIGQUERY_PROJECT_ID,
           credentials: credentials,
         });
         this.isConfigured = true;
@@ -84,8 +85,8 @@ export class BigQueryService {
       throw new Error('BigQuery service not configured');
     }
     
-    const dataset = process.env.BIGQUERY_DATASET || 'SE_Enrichment';
-    const table = process.env.BIGQUERY_TABLE || 'supplier';
+    const dataset = env.BIGQUERY_DATASET;
+    const table = env.BIGQUERY_TABLE;
     
     // Query with confidence scoring based on match quality
     const query = `
@@ -122,7 +123,7 @@ export class BigQueryService {
             WHEN LOWER(COALESCE(mastercard_business_name_c, '')) LIKE CONCAT('%', LOWER(@payeeName), '%') THEN 'Mastercard name contains payee name'
             ELSE 'Partial text match'
           END AS match_reasoning
-        FROM \`${process.env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
+        FROM \`${env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
         WHERE COALESCE(is_deleted, false) = false
           AND (
             LOWER(name) LIKE CONCAT('%', LOWER(@payeeName), '%')
@@ -195,8 +196,8 @@ export class BigQueryService {
       throw new Error('BigQuery service not configured');
     }
     
-    const dataset = process.env.BIGQUERY_DATASET || 'SE_Enrichment';
-    const table = process.env.BIGQUERY_TABLE || 'supplier';
+    const dataset = env.BIGQUERY_DATASET;
+    const table = env.BIGQUERY_TABLE;
     
     // Query to get DISTINCT suppliers with proper handling of duplicates
     const query = `
@@ -212,7 +213,7 @@ export class BigQueryService {
           primary_address_city_c,
           primary_address_state_c,
           ROW_NUMBER() OVER (PARTITION BY LOWER(name) ORDER BY id) as rn
-        FROM \`${process.env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
+        FROM \`${env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
         WHERE COALESCE(is_deleted, false) = false
           AND name IS NOT NULL
           AND LENGTH(TRIM(name)) > 0
@@ -285,8 +286,8 @@ export class BigQueryService {
     }
 
     try {
-      const dataset = process.env.BIGQUERY_DATASET || 'SE_Enrichment';
-      const table = process.env.BIGQUERY_MATCH_METRICS_TABLE || 'fuzzy_match_metrics';
+      const dataset = env.BIGQUERY_DATASET;
+      const table = env.BIGQUERY_MATCH_METRICS_TABLE;
       await this.bigquery.dataset(dataset).table(table).insert([record]);
     } catch (error) {
       console.error('Error logging match metric to BigQuery:', error);

--- a/server/services/classification.ts
+++ b/server/services/classification.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { storage } from "../storage";
 import { type InsertPayeeClassification } from "@shared/schema";
 import OpenAI from 'openai';
@@ -49,7 +50,7 @@ class RateLimiter {
 }
 
 // the newest OpenAI model is "gpt-4o" which was released May 13, 2024. do not change this unless explicitly requested by the user
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
 const rateLimiter = new RateLimiter();
 
 export interface ClassificationResult {

--- a/server/services/classificationV2.ts
+++ b/server/services/classificationV2.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { storage } from "../storage";
 import { type InsertPayeeClassification, type PayeeClassification, payeeClassifications } from "@shared/schema";
 import { db } from "../db";
@@ -17,13 +18,13 @@ import { eq, desc, and } from 'drizzle-orm';
 import { FuzzyMatcher } from './fuzzyMatcher';
 
 // Validate OpenAI API key
-if (!process.env.OPENAI_API_KEY) {
+if (!env.OPENAI_API_KEY) {
   throw new Error('OPENAI_API_KEY environment variable is required');
 }
 
 // Initialize OpenAI with Tier 5 performance settings
 const openai = new OpenAI({ 
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: env.OPENAI_API_KEY,
   maxRetries: 5,
   timeout: 20000 // 20 second timeout for faster retries
 });
@@ -1541,7 +1542,7 @@ Example: [["JPMorgan Chase", "Chase Bank"], ["Bank of America", "BofA"]]`
       }
 
       // Check if Akkio API is configured
-      if (!process.env.AKKIO_API_KEY) {
+      if (!env.AKKIO_API_KEY) {
         console.log('Akkio API not configured, skipping predictions');
         
         await storage.updateUploadBatch(batchId, {

--- a/server/services/connectionPool.ts
+++ b/server/services/connectionPool.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Enterprise Database Connection Pool Manager
  * Manages database connections with health checks and recovery
@@ -63,9 +64,9 @@ class ConnectionPoolManager {
     this.pool = new Pool({
       ...this.config,
       // Connection string from environment
-      connectionString: process.env.DATABASE_URL,
+      connectionString: env.DATABASE_URL,
       // SSL for production
-      ssl: process.env.NODE_ENV === 'production' ? {
+      ssl: env.NODE_ENV === 'production' ? {
         rejectUnauthorized: false
       } : undefined,
       // Statement timeout to prevent long-running queries
@@ -296,8 +297,8 @@ class ConnectionPoolManager {
 
 // Create singleton instance with enterprise configuration
 export const poolManager = new ConnectionPoolManager({
-  max: parseInt(process.env.DB_POOL_SIZE || '20'),
-  min: parseInt(process.env.DB_POOL_MIN || '5'),
+  max: env.DB_POOL_SIZE,
+  min: env.DB_POOL_MIN,
   idleTimeoutMillis: 30000,
   connectionTimeoutMillis: 5000,
   healthCheckInterval: 30000,

--- a/server/services/dailySupplierSync.ts
+++ b/server/services/dailySupplierSync.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { BigQuery } from '@google-cloud/bigquery';
 import { db } from '../db';
 import { cachedSuppliers } from '@shared/schema';
@@ -9,10 +10,10 @@ export class DailySupplierSync {
   
   private constructor() {
     this.bigquery = new BigQuery({
-      projectId: process.env.BIGQUERY_PROJECT_ID,
-      keyFilename: process.env.BIGQUERY_KEY_FILE,
-      credentials: process.env.BIGQUERY_CREDENTIALS ? 
-        JSON.parse(process.env.BIGQUERY_CREDENTIALS) : undefined
+      projectId: env.BIGQUERY_PROJECT_ID,
+      keyFilename: env.BIGQUERY_KEY_FILE,
+      credentials: env.BIGQUERY_CREDENTIALS ? 
+        JSON.parse(env.BIGQUERY_CREDENTIALS) : undefined
     });
   }
   
@@ -27,8 +28,8 @@ export class DailySupplierSync {
     console.log('🚀 Starting daily supplier sync from BigQuery...');
     
     try {
-      const dataset = process.env.BIGQUERY_DATASET || 'SE_Enrichment';
-      const table = process.env.BIGQUERY_TABLE || 'supplier';
+      const dataset = env.BIGQUERY_DATASET;
+      const table = env.BIGQUERY_TABLE;
       
       // Query ALL distinct suppliers from BigQuery
       const query = `
@@ -38,7 +39,7 @@ export class DailySupplierSync {
             name,
             payment_type_c,
             ROW_NUMBER() OVER (PARTITION BY LOWER(name) ORDER BY id) as rn
-          FROM \`${process.env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
+          FROM \`${env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
           WHERE COALESCE(is_deleted, false) = false
             AND name IS NOT NULL
             AND LENGTH(TRIM(name)) > 0

--- a/server/services/fieldPredictionService.ts
+++ b/server/services/fieldPredictionService.ts
@@ -1,7 +1,8 @@
+import { env } from '../config';
 import { OpenAI } from "openai";
 
 const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
+  apiKey: env.OPENAI_API_KEY,
 });
 
 export interface FieldPrediction {

--- a/server/services/fuzzyMatcher.ts
+++ b/server/services/fuzzyMatcher.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import OpenAI from 'openai';
 import { LRUCache } from 'lru-cache';
 import { bigQueryService } from './bigQueryService';
@@ -20,10 +21,10 @@ export class FuzzyMatcher {
 
   constructor() {
     // Allow OpenAI usage to be disabled for low latency requirements
-    this.aiDisabled = process.env.DISABLE_OPENAI === 'true';
+    this.aiDisabled = env.DISABLE_OPENAI;
 
-    if (process.env.OPENAI_API_KEY && !this.aiDisabled) {
-      this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    if (env.OPENAI_API_KEY && !this.aiDisabled) {
+      this.openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
       console.log('FuzzyMatcher: OpenAI initialized successfully');
     } else if (this.aiDisabled) {
       console.log('FuzzyMatcher: OpenAI disabled via configuration');

--- a/server/services/gracefulShutdown.ts
+++ b/server/services/gracefulShutdown.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Enterprise Graceful Shutdown Handler
  * Ensures clean shutdown of all services and connections
@@ -153,7 +154,7 @@ class GracefulShutdown {
     const tasks = [];
     
     // Close Redis connections if available
-    if (process.env.REDIS_URL) {
+    if (env.REDIS_URL) {
       tasks.push(this.closeRedis());
     }
     

--- a/server/services/healthMonitor.ts
+++ b/server/services/healthMonitor.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Enterprise Health Monitoring Service
  * Comprehensive health checks and monitoring
@@ -256,10 +257,10 @@ class HealthMonitor {
 
   private async checkDependencies(): Promise<ComponentHealth> {
     const dependencies = {
-      openai: !!process.env.OPENAI_API_KEY,
-      mastercard: !!process.env.MASTERCARD_CONSUMER_KEY,
-      database: !!process.env.DATABASE_URL,
-      redis: !!process.env.REDIS_URL
+      openai: !!env.OPENAI_API_KEY,
+      mastercard: !!env.MASTERCARD_CONSUMER_KEY,
+      database: !!env.DATABASE_URL,
+      redis: !!env.REDIS_URL
     };
     
     const missing = Object.entries(dependencies)

--- a/server/services/intelligentAddressService.ts
+++ b/server/services/intelligentAddressService.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import OpenAI from 'openai';
 import { addressValidationService } from './addressValidationService';
 
@@ -32,8 +33,8 @@ export class IntelligentAddressService {
   private openai: OpenAI | null;
   
   constructor() {
-    if (process.env.OPENAI_API_KEY) {
-      this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    if (env.OPENAI_API_KEY) {
+      this.openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
     } else {
       this.openai = null;
       console.warn('⚠️ OpenAI API key not configured - intelligent address enhancement disabled');

--- a/server/services/logger.ts
+++ b/server/services/logger.ts
@@ -1,5 +1,6 @@
+import { env } from '../config';
 export class Logger {
-  private isProduction = process.env.NODE_ENV === 'production';
+  private isProduction = env.NODE_ENV === 'production';
   
   debug(message: string, ...args: any[]) {
     if (!this.isProduction) {

--- a/server/services/mastercardApi.ts
+++ b/server/services/mastercardApi.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import crypto from 'crypto';
 import fs from 'fs';
 import { z } from 'zod';
@@ -31,37 +32,37 @@ function generateOAuthHeader(method: string, url: string, consumerKey: string, p
 const MASTERCARD_CONFIG = {
   sandbox: {
     baseUrl: 'https://sandbox.api.mastercard.com/track/search',
-    consumerKey: process.env.MASTERCARD_CONSUMER_KEY,
-    privateKey: process.env.MASTERCARD_KEY || process.env.MASTERCARD_PRIVATE_KEY,
-    certificate: process.env.MASTERCARD_CERT,
+    consumerKey: env.MASTERCARD_CONSUMER_KEY,
+    privateKey: env.MASTERCARD_KEY || env.MASTERCARD_PRIVATE_KEY,
+    certificate: env.MASTERCARD_CERT,
     privateKeyPath: './mastercard-private-key.pem',
-    p12Path: process.env.MASTERCARD_P12_PATH || './Finexio_MasterCard_Production_2025-production.p12',
-    keystorePassword: process.env.MASTERCARD_KEYSTORE_PASSWORD,
-    keystoreAlias: process.env.MASTERCARD_KEY_ALIAS || process.env.MASTERCARD_KEYSTORE_ALIAS,
+    p12Path: env.MASTERCARD_P12_PATH || './Finexio_MasterCard_Production_2025-production.p12',
+    keystorePassword: env.MASTERCARD_KEYSTORE_PASSWORD,
+    keystoreAlias: env.MASTERCARD_KEY_ALIAS || env.MASTERCARD_KEYSTORE_ALIAS,
     // Extract clientId from consumer key (part after the !)
-    clientId: process.env.MASTERCARD_CLIENT_ID || process.env.MASTERCARD_CONSUMER_KEY?.split('!')[1],
+    clientId: env.MASTERCARD_CLIENT_ID || env.MASTERCARD_CONSUMER_KEY?.split('!')[1],
   },
   production: {
     baseUrl: 'https://api.mastercard.com/track/search',
-    consumerKey: process.env.MASTERCARD_CONSUMER_KEY,
-    privateKey: process.env.MASTERCARD_KEY || process.env.MASTERCARD_PRIVATE_KEY,
-    certificate: process.env.MASTERCARD_CERT,
+    consumerKey: env.MASTERCARD_CONSUMER_KEY,
+    privateKey: env.MASTERCARD_KEY || env.MASTERCARD_PRIVATE_KEY,
+    certificate: env.MASTERCARD_CERT,
     privateKeyPath: './mastercard-private-key.pem',
-    p12Path: process.env.MASTERCARD_P12_PATH || './Finexio_MasterCard_Production_2025-production.p12',
-    keystorePassword: process.env.MASTERCARD_KEYSTORE_PASSWORD,
-    keystoreAlias: process.env.MASTERCARD_KEY_ALIAS || process.env.MASTERCARD_KEYSTORE_ALIAS,
+    p12Path: env.MASTERCARD_P12_PATH || './Finexio_MasterCard_Production_2025-production.p12',
+    keystorePassword: env.MASTERCARD_KEYSTORE_PASSWORD,
+    keystoreAlias: env.MASTERCARD_KEY_ALIAS || env.MASTERCARD_KEYSTORE_ALIAS,
     // Extract clientId from consumer key (part after the !)
-    clientId: process.env.MASTERCARD_CLIENT_ID || process.env.MASTERCARD_CONSUMER_KEY?.split('!')[1],
+    clientId: env.MASTERCARD_CLIENT_ID || env.MASTERCARD_CONSUMER_KEY?.split('!')[1],
   }
 };
 
 // Use production environment in production, sandbox in development
-const environment = process.env.NODE_ENV === 'production' ? 'production' : (process.env.MASTERCARD_ENVIRONMENT || 'sandbox');
+const environment = env.NODE_ENV === 'production' ? 'production' : env.MASTERCARD_ENVIRONMENT;
 const config = MASTERCARD_CONFIG[environment as keyof typeof MASTERCARD_CONFIG];
 
 // Log environment configuration at startup
 console.log('🌐 Mastercard Environment Configuration:', {
-  NODE_ENV: process.env.NODE_ENV,
+  NODE_ENV: env.NODE_ENV,
   selectedEnvironment: environment,
   baseUrl: config.baseUrl,
   hasConsumerKey: !!config.consumerKey,
@@ -205,7 +206,7 @@ export class MastercardApiService {
 
   private initializeCredentials(): boolean {
     console.log('🔐 Initializing Mastercard credentials...');
-    console.log(`   Environment: ${environment} (NODE_ENV=${process.env.NODE_ENV})`);
+    console.log(`   Environment: ${environment} (NODE_ENV=${env.NODE_ENV})`);
     console.log(`   API URL: ${config.baseUrl}`);
     
     // Check for consumer key

--- a/server/services/mastercardWorking.ts
+++ b/server/services/mastercardWorking.ts
@@ -1,9 +1,10 @@
+import { env } from '../config';
 // Working Mastercard implementation that retrieves real data
 import fs from 'fs';
 import oauth from 'mastercard-oauth1-signer';
 
 const config = {
-  consumerKey: process.env.MASTERCARD_CONSUMER_KEY || '8Mg4p8h-0kO7rNwUlRfWhRyvQlzRphvEEujbNW8yabd509dd!e09833ad819042f695507b05bdd001230000000000000000',
+  consumerKey: env.MASTERCARD_CONSUMER_KEY || '8Mg4p8h-0kO7rNwUlRfWhRyvQlzRphvEEujbNW8yabd509dd!e09833ad819042f695507b05bdd001230000000000000000',
   clientId: 'e09833ad819042f695507b05bdd001230000000000000000',
   privateKeyPath: './mastercard-private-key.pem',
   baseUrl: 'https://api.mastercard.com/track/search'

--- a/server/services/payeeMatchingService.ts
+++ b/server/services/payeeMatchingService.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { bigQueryService, type BigQueryPayeeResult } from './bigQueryService';
 import { fuzzyMatcher } from './fuzzyMatcher';
 import { storage } from '../storage';
@@ -21,8 +22,8 @@ export class PayeeMatchingService {
   private openai: OpenAI | null = null;
   
   constructor() {
-    if (process.env.OPENAI_API_KEY) {
-      this.openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    if (env.OPENAI_API_KEY) {
+      this.openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
     }
   }
 

--- a/server/services/rateLimiter.ts
+++ b/server/services/rateLimiter.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 /**
  * Enterprise Rate Limiting Service
  * Advanced rate limiting with multiple strategies
@@ -162,7 +163,7 @@ export class RateLimiterFactory {
   
   static create(name: string, options: RateLimitOptions): RateLimitStore {
     if (!this.limiters.has(name)) {
-      const limiter = process.env.REDIS_URL 
+      const limiter = env.REDIS_URL 
         ? new DistributedRateLimiter(options)
         : new SlidingWindowRateLimiter(options);
       

--- a/server/services/supplierCacheService.ts
+++ b/server/services/supplierCacheService.ts
@@ -1,3 +1,4 @@
+import { env } from '../config';
 import { db } from '../db';
 import { cachedSuppliers, type InsertCachedSupplier } from '@shared/schema';
 import { bigQueryService } from './bigQueryService';
@@ -95,15 +96,15 @@ export class SupplierCacheService {
           mastercard_business_name_c as mastercardBusinessName,
           primary_address_city_c as city,
           primary_address_state_c as state
-        FROM \`${process.env.BIGQUERY_PROJECT_ID}.${process.env.BIGQUERY_DATASET || 'SE_Enrichment'}.${process.env.BIGQUERY_TABLE || 'supplier'}\`
+        FROM \`${env.BIGQUERY_PROJECT_ID}.${env.BIGQUERY_DATASET}.${env.BIGQUERY_TABLE}\`
         WHERE COALESCE(is_deleted, false) = false
         LIMIT ${limit}
       `;
 
       // Use the public searchKnownPayees method to get all suppliers
       // For syncing, we'll use a generic query
-      const dataset = process.env.BIGQUERY_DATASET || 'SE_Enrichment';
-      const table = process.env.BIGQUERY_TABLE || 'supplier';
+      const dataset = env.BIGQUERY_DATASET;
+      const table = env.BIGQUERY_TABLE;
       
       // Create a temporary method to get all suppliers
       const allSuppliersQuery = `
@@ -117,7 +118,7 @@ export class SupplierCacheService {
           mastercard_business_name_c as mastercardBusinessName,
           primary_address_city_c as city,
           primary_address_state_c as state
-        FROM \`${process.env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
+        FROM \`${env.BIGQUERY_PROJECT_ID}.${dataset}.${table}\`
         WHERE COALESCE(is_deleted, false) = false
         LIMIT ${limit}
       `;


### PR DESCRIPTION
## Summary
- add `server/config.ts` with zod-based schema to validate required environment values and provide sensible defaults
- refactor server modules to consume typed `env` instead of `process.env`

## Testing
- `npm run check` *(fails: 'error' is of type 'unknown', implicit any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a2550f408321a3d55b1d029e4df6