### PR TITLE
refactor: replace console usage with centralized logger

### DIFF
--- a/server/apiGateway.ts
+++ b/server/apiGateway.ts
@@ -4,9 +4,9 @@
  */
 
 import { Request, Response } from 'express';
-import { 
-  classificationQueue, 
-  finexioQueue, 
+import {
+  classificationQueue,
+  finexioQueue,
   mastercardQueue,
   addressQueue,
   akkioQueue,
@@ -14,6 +14,7 @@ import {
   checkQueueHealth
 } from './services/queueService';
 import { nanoid } from 'nanoid';
+import logger from './logger';
 
 // Job status tracking (in production, use Redis)
 const jobStatuses = new Map<string, any>();
@@ -273,7 +274,7 @@ export function queueMiddleware(
       });
       
     } catch (error) {
-      console.error(`Error adding job to ${queueName} queue:`, error);
+      logger.error(`Error adding job to ${queueName} queue:`, error);
       res.status(500).json({
         error: 'Failed to queue job',
         details: error.message
@@ -289,7 +290,7 @@ export function useMicroservices(): boolean {
   return process.env.ENABLE_MICROSERVICES === 'true';
 }
 
-console.log(`🚀 API Gateway initialized (Microservices: ${useMicroservices() ? 'ENABLED' : 'DISABLED'})`);
+logger.info(`🚀 API Gateway initialized (Microservices: ${useMicroservices() ? 'ENABLED' : 'DISABLED'})`);
 
 export default {
   classifyViaQueue,

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,6 +2,7 @@ import { Pool, neonConfig } from '@neondatabase/serverless';
 import { drizzle } from 'drizzle-orm/neon-serverless';
 import ws from "ws";
 import * as schema from "@shared/schema";
+import logger from './logger';
 
 // Configure WebSocket for Neon in Node.js environment
 neonConfig.webSocketConstructor = ws;
@@ -27,14 +28,14 @@ export const pool = new Pool({
 
 // Add error handling for the pool
 pool.on('error', (err) => {
-  console.error('Database pool error:', err);
+  logger.error('Database pool error:', err);
 });
 
 pool.on('connect', () => {
-  console.log('Database pool connected');
+  logger.info('Database pool connected');
 });
 
 // Test connection on module load
-console.log('Database module loaded, testing basic connection...');
+logger.info('Database module loaded, testing basic connection...');
 
 export const db = drizzle({ client: pool, schema });

--- a/server/middleware/errorHandler.ts
+++ b/server/middleware/errorHandler.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
+import logger from '../logger';
 
 // Custom error class for application errors
 export class AppError extends Error {
@@ -17,7 +18,7 @@ export class AppError extends Error {
 
 // Database error handler
 export function handleDatabaseError(error: any): AppError {
-  console.error('Database error:', error);
+  logger.error('Database error:', error);
   
   // Handle specific PostgreSQL error codes
   if (error.code === '57P01') {
@@ -85,7 +86,7 @@ export function errorHandler(
   }
   
   // Log error details
-  console.error('Error handler caught:', {
+  logger.error('Error handler caught:', {
     statusCode,
     message,
     stack: err.stack,

--- a/server/routes/health.ts
+++ b/server/routes/health.ts
@@ -4,6 +4,7 @@ import { bigQueryService } from '../services/bigQueryService';
 import { addressValidationService } from '../services/addressValidationService';
 import { cachedSuppliers } from '@shared/schema';
 import { sql } from 'drizzle-orm';
+import logger from '../logger';
 
 const router = Router();
 
@@ -315,7 +316,7 @@ router.get('/mastercard', async (req, res) => {
       });
     }
   } catch (error) {
-    console.error('Health check error:', error);
+    logger.error('Health check error:', error);
     res.status(500).json({
       status: 'error',
       error: error instanceof Error ? error.message : 'Unknown error',


### PR DESCRIPTION
## Summary
- replace console statements with `logger` in core server modules
- ensure database, API gateway, health route and error handler use consistent logging
- bootstrap process now logs via `logger` for startup and shutdown events

## Testing
- `npm run check` *(fails: Type 'string | number' is not assignable to type 'string' ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a2533190832180261a0abd98459a