### PR TITLE
Add client error boundary for crash recovery

### DIFF
--- a/client/src/components/error-boundary.tsx
+++ b/client/src/components/error-boundary.tsx
@@ -1,0 +1,59 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+    try {
+      fetch("/api/log-client-error", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          error: error.toString(),
+          info: errorInfo.componentStack,
+        }),
+      });
+    } catch (logError) {
+      console.error("Failed to report client error", logError);
+    }
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-screen flex-col items-center justify-center gap-4">
+          <h1 className="text-2xl font-semibold">Something went wrong.</h1>
+          <Button onClick={this.handleReload}>Reload Page</Button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import ErrorBoundary from "@/components/error-boundary";
 import "./index.css";
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- introduce ErrorBoundary component to catch client errors, log them, and offer page reload
- wrap <App /> with ErrorBoundary in main entry point

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors in server services)


------
https://chatgpt.com/codex/tasks/task_e_68a7a256a64c832190d75985768b9084