### PR TITLE
feat: add service worker for offline caching

### DIFF
--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -8,3 +8,11 @@ createRoot(document.getElementById("root")!).render(
     <App />
   </ErrorBoundary>
 );
+
+if ("serviceWorker" in navigator && import.meta.env.PROD) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker
+      .register("/sw.js")
+      .catch((err) => console.error("Service worker registration failed:", err));
+  });
+}

--- a/client/src/sw.ts
+++ b/client/src/sw.ts
@@ -1,0 +1,71 @@
+/// <reference lib="webworker" />
+
+export {}
+
+const STATIC_CACHE = 'static-v1';
+const API_CACHE = 'api-v1';
+const STATIC_ASSETS = ['/','/index.html'];
+
+self.addEventListener('install', (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.open(STATIC_CACHE).then((cache) => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event: ExtendableEvent) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (![STATIC_CACHE, API_CACHE].includes(key)) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event: FetchEvent) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  // Handle navigation requests
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request).catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+
+  // Cache API responses with network-first strategy
+  if (url.pathname.startsWith('/api')) {
+    event.respondWith(
+      caches.open(API_CACHE).then((cache) =>
+        fetch(request)
+          .then((response) => {
+            cache.put(request, response.clone());
+            return response;
+          })
+          .catch(() => cache.match(request))
+      )
+    );
+    return;
+  }
+
+  // Cache-first strategy for other GET requests (static assets)
+  if (request.method === 'GET' && request.destination !== 'document') {
+    event.respondWith(
+      caches.match(request).then((cached) => {
+        if (cached) return cached;
+        return fetch(request).then((response) => {
+          const copy = response.clone();
+          caches.open(STATIC_CACHE).then((cache) => cache.put(request, copy));
+          return response;
+        });
+      })
+    );
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,16 @@ export default defineConfig({
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: path.resolve(import.meta.dirname, "client/index.html"),
+        sw: path.resolve(import.meta.dirname, "client/src/sw.ts"),
+      },
+      output: {
+        entryFileNames: (chunk) =>
+          chunk.name === "sw" ? "sw.js" : "assets/[name]-[hash].js",
+      },
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary
- add service worker to cache static assets and API responses
- register service worker in main entry and build config

## Testing
- `npm test` *(fails: Invalid environment variables)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7af849ec48321a2d90db8decba4a6