### PR TITLE
Add error boundary around router with recovery actions

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import ErrorBoundary from "@/components/error-boundary";
 import Home from "@/pages/home";
 import NotFound from "@/pages/not-found";
 import { AkkioModels } from "@/pages/akkio-models";
@@ -28,7 +29,9 @@ function App() {
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <Toaster />
-        <Router />
+        <ErrorBoundary>
+          <Router />
+        </ErrorBoundary>
       </TooltipProvider>
     </QueryClientProvider>
   );

--- a/client/src/components/error-boundary.tsx
+++ b/client/src/components/error-boundary.tsx
@@ -42,12 +42,21 @@ export class ErrorBoundary extends Component<
     window.location.reload();
   };
 
+  handleReport = () => {
+    window.open("mailto:support@example.com?subject=App%20Error&body=Describe%20what%20happened", "_blank");
+  };
+
   render() {
     if (this.state.hasError) {
       return (
         <div className="flex h-screen flex-col items-center justify-center gap-4">
           <h1 className="text-2xl font-semibold">Something went wrong.</h1>
-          <Button onClick={this.handleReload}>Reload Page</Button>
+          <div className="flex gap-2">
+            <Button onClick={this.handleReload}>Reload Page</Button>
+            <Button variant="outline" onClick={this.handleReport}>
+              Report Issue
+            </Button>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
## Summary
- add custom error boundary component with reload and report issue options
- wrap app router with error boundary for global crash handling

## Testing
- `npm test` *(fails: Invalid environment variables: DATABASE_URL Required)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af8771308321ac77aef0c038ba53