### PR TITLE
Send credentials with upload requests

### DIFF
--- a/client/src/components/upload/file-upload.tsx
+++ b/client/src/components/upload/file-upload.tsx
@@ -56,6 +56,7 @@ export default function FileUpload({
         });
 
         xhr.open("POST", "/api/upload");
+        xhr.withCredentials = true;
         xhr.send(formData);
       });
     },

--- a/client/src/pages/upload.tsx
+++ b/client/src/pages/upload.tsx
@@ -40,6 +40,7 @@ export default function Upload() {
       const response = await fetch("/api/upload/preview", {
         method: "POST",
         body: formData,
+        credentials: "include",
       });
       
       if (!response.ok) {
@@ -78,6 +79,7 @@ export default function Upload() {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ tempFileName, originalFilename, payeeColumn }),
+        credentials: "include",
       });
       
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- ensure XHR uploads send cookies by enabling `withCredentials`
- include browser session cookies on upload preview and process fetches

## Testing
- `npm test` *(fails: Invalid environment variables: DATABASE_URL required)*
- `npm run check` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_b_68a891756b808331be2cd744436c85ef