### PR TITLE
refactor: centralize upload file validation

### DIFF
--- a/client/src/components/upload/file-upload.tsx
+++ b/client/src/components/upload/file-upload.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
 import { useToast } from "@/hooks/use-toast";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { validateFile } from "@/lib/validateUpload";
 
 interface FileUploadProps {
   onUploadSuccess?: (result: any) => void;
@@ -79,26 +80,14 @@ export default function FileUpload({
     },
   });
 
-  const validateFile = (file: File): string | null => {
-    // Check file type
-    const allowedExtensions = accept.split(",").map(ext => ext.trim().toLowerCase());
-    const fileExtension = file.name.toLowerCase().substring(file.name.lastIndexOf("."));
-    
-    if (!allowedExtensions.includes(fileExtension)) {
-      return `Invalid file type. Allowed types: ${allowedExtensions.join(", ")}`;
-    }
-
-    // Check file size
-    if (file.size > maxSize) {
-      const maxSizeMB = Math.round(maxSize / (1024 * 1024));
-      return `File too large. Maximum size: ${maxSizeMB}MB`;
-    }
-
-    return null;
-  };
-
   const handleFileUpload = (file: File) => {
-    const validationError = validateFile(file);
+    const allowedExtensions = accept
+      .split(",")
+      .map((ext) => ext.trim().toLowerCase());
+    const validationError = validateFile(file, {
+      allowedExtensions,
+      maxSize,
+    });
     if (validationError) {
       toast({
         title: "Invalid file",

--- a/client/src/lib/validateUpload.ts
+++ b/client/src/lib/validateUpload.ts
@@ -1,0 +1,19 @@
+export interface ValidateOptions {
+  allowedExtensions: string[];
+  maxSize: number; // in bytes
+}
+
+export function validateFile(file: File, { allowedExtensions, maxSize }: ValidateOptions): string | null {
+  const ext = file.name.toLowerCase().substring(file.name.lastIndexOf('.'));
+  const normalized = allowedExtensions.map(e => e.trim().toLowerCase());
+  if (!normalized.includes(ext)) {
+    return `Invalid file type. Allowed types: ${normalized.join(', ')}`;
+  }
+
+  if (file.size > maxSize) {
+    const maxSizeMB = Math.round(maxSize / (1024 * 1024));
+    return `File too large. Maximum size: ${maxSizeMB}MB`;
+  }
+
+  return null;
+}

--- a/client/src/pages/upload.tsx
+++ b/client/src/pages/upload.tsx
@@ -10,6 +10,7 @@ import type { UploadBatch, ClassificationStats } from "@/lib/types";
 import ProgressTracker from "@/components/ui/progress-tracker";
 import { Badge } from "@/components/ui/badge";
 import { Trash2 } from "lucide-react";
+import { validateFile } from "@/lib/validateUpload";
 
 interface FilePreview {
   filename: string;
@@ -133,24 +134,15 @@ export default function Upload() {
   };
 
   const handleFileUpload = (file: File) => {
-    // Validate file type
-    const allowedTypes = [".csv", ".xlsx", ".xls"];
-    const fileExtension = file.name.toLowerCase().substring(file.name.lastIndexOf("."));
-    
-    if (!allowedTypes.includes(fileExtension)) {
-      toast({
-        title: "Invalid file type",
-        description: "Please upload a CSV or Excel file.",
-        variant: "destructive",
-      });
-      return;
-    }
+    const validationError = validateFile(file, {
+      allowedExtensions: [".csv", ".xlsx", ".xls"],
+      maxSize: 10 * 1024 * 1024,
+    });
 
-    // Validate file size (max 10MB)
-    if (file.size > 10 * 1024 * 1024) {
+    if (validationError) {
       toast({
-        title: "File too large",
-        description: "Please upload a file smaller than 10MB.",
+        title: "Invalid file",
+        description: validationError,
         variant: "destructive",
       });
       return;

--- a/tests/validateUpload.test.ts
+++ b/tests/validateUpload.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { validateFile } from '../client/src/lib/validateUpload';
+
+describe('validateFile', () => {
+  it('returns null for valid files', () => {
+    const file = new File(['data'], 'test.csv');
+    const result = validateFile(file, {
+      allowedExtensions: ['.csv'],
+      maxSize: 1024,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('rejects invalid file types', () => {
+    const file = new File(['data'], 'test.txt');
+    const result = validateFile(file, {
+      allowedExtensions: ['.csv'],
+      maxSize: 1024,
+    });
+    expect(result).toMatch(/Invalid file type/);
+  });
+
+  it('rejects files that are too large', () => {
+    const file = new File([new Uint8Array(2)], 'test.csv');
+    const result = validateFile(file, {
+      allowedExtensions: ['.csv'],
+      maxSize: 1,
+    });
+    expect(result).toMatch(/File too large/);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared `validateFile` utility for upload validation
- use utility in upload components to check extension and size
- cover valid and invalid cases with unit tests

## Testing
- `npm test` *(fails: Invalid environment variables: DATABASE_URL required)*
- `npx vitest run tests/validateUpload.test.ts`


------
https://chatgpt.com/codex/tasks/task_b_68a8917348908331a3d678bc111d9921