### PR TITLE
feat: improve accessibility of file upload drop zone

### DIFF
--- a/client/src/components/upload/file-upload.tsx
+++ b/client/src/components/upload/file-upload.tsx
@@ -148,14 +148,21 @@ export default function FileUpload({
     fileInputRef.current?.click();
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleChooseFile();
+    }
+  };
+
   const isUploading = uploadMutation.isPending;
 
   return (
     <div className="w-full">
       <div
-        className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors ${
+        className={`border-2 border-dashed rounded-lg p-8 text-center transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 ${
           dragActive && !disabled && !isUploading
-            ? "border-primary-500 bg-primary-50" 
+            ? "border-primary-500 bg-primary-50"
             : disabled || isUploading
             ? "border-gray-200 bg-gray-50 cursor-not-allowed"
             : "border-gray-300 hover:border-primary-400 hover:bg-primary-50 cursor-pointer"
@@ -165,6 +172,10 @@ export default function FileUpload({
         onDragOver={handleDrag}
         onDrop={handleDrop}
         onClick={handleChooseFile}
+        onKeyDown={handleKeyDown}
+        role="button"
+        tabIndex={0}
+        aria-label="File upload area. Press Enter or Space to browse for files"
       >
         <input
           ref={fileInputRef}


### PR DESCRIPTION
## Summary
- make file upload drop zone keyboard-accessible via role, tab index, and onKeyDown handler
- add aria-label and visible focus styles for the drop zone

## Testing
- ⚠️ `npm test` (fails: Invalid environment variables)
- ⚠️ `npm run check` (fails: multiple TS errors)


------
https://chatgpt.com/codex/tasks/task_b_68a8917483bc833199fd69c349567875