### PR TITLE
feat: add reusable confirmation modal for job deletions

### DIFF
--- a/client/src/components/ui/confirmation-modal.tsx
+++ b/client/src/components/ui/confirmation-modal.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog"
+
+interface ConfirmationModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  title: string
+  description?: string
+  confirmText?: string
+  cancelText?: string
+  onConfirm: () => void
+}
+
+export function ConfirmationModal({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmText = "Delete",
+  cancelText = "Cancel",
+  onConfirm,
+}: ConfirmationModalProps) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription>{description}</AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{cancelText}</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={() => {
+              onConfirm()
+              onOpenChange(false)
+            }}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}


### PR DESCRIPTION
## Summary
- add a reusable `ConfirmationModal` built on AlertDialog with cancel and destructive delete actions
- replace native `confirm()` prompts in upload page with the new modal for deleting failed jobs, all jobs, or an individual job

## Testing
- `npm test` *(fails: Invalid environment variables: DATABASE_URL required)*

------
https://chatgpt.com/codex/tasks/task_b_68a89171e77883318c2c87a632c551bf